### PR TITLE
 fixes crash during ethernet devices enumeration/search

### DIFF
--- a/src/ed247/ed247_cominterface.cpp
+++ b/src/ed247/ed247_cominterface.cpp
@@ -463,7 +463,7 @@ void UdpSocket::Factory::setup()
 
     getifaddrs (&ifap);
     for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
-        if (ifa->ifa_addr->sa_family==AF_INET) {
+        if (ifa->ifa_addr!=NULL && ifa->ifa_addr->sa_family==AF_INET) {
             sa = (struct sockaddr_in *) ifa->ifa_addr;
             _host_ip_addresses.emplace_back(sa->sin_addr);
             LOG_DEBUG() << "# Available ip address [" << std::string(inet_ntoa(_host_ip_addresses.back())) << "]" << LOG_END;


### PR DESCRIPTION
As captured in the documentation, the parameter "ifa_addr" may be NULL. So it must be checked for NULL before being dereferenced. Not doing this was causing crashes on my machine.