### PR TITLE
Build Error Fix

### DIFF
--- a/src/ed247/ed247_xml.cpp
+++ b/src/ed247/ed247_xml.cpp
@@ -27,6 +27,7 @@
 #include "ed247_xsd.h"
 #include <libxml/xmlschemas.h>
 #include <algorithm>
+#include <limits>
 
 /*
  * ECIC Nodes and attributes


### PR DESCRIPTION
If this include isn't added, there is a build error that occurs.